### PR TITLE
Update umlaut_services.yml

### DIFF
--- a/config/umlaut_services.yml
+++ b/config/umlaut_services.yml
@@ -23,7 +23,7 @@ default:
       holding_search_institution: NYU
       holding_search_text: Search for this title in BobCat.
       suppress_holdings: [ !ruby/regexp '/\$\$LBWEB/', !ruby/regexp '/\$\$LNWEB/', !ruby/regexp '/\$\$LTWEB/', !ruby/regexp '/\$\$LSWEB/', !ruby/regexp '/\$\$LWEB/', !ruby/regexp '/\$\$ONSMARCIT/', !ruby/regexp '/\$\$Onyumarcit/', !ruby/regexp '/\$\$1Restricted Internet Resources/' ]
-      suppress_urls: [ !ruby/regexp '/https\:\/\/getit\.library\.nyu\.edu/', !ruby/regexp '/https\:\/\/www\.loc\.gov\/catdir\/toc/']
+      suppress_urls: [ !ruby/regexp '/getit\.library\.nyu\.edu/', !ruby/regexp '/www\.loc\.gov\/catdir\/toc/']
       ez_proxy: !ruby/regexp '/https\:\/\/ezproxy\.library\.nyu\.edu\/login\?url=/'
       service_types:
         - primo_source


### PR DESCRIPTION
added getit URL mask so that marcit 856s do not display (perhaps this should be $O/$L holdings?)
