### PR TITLE
url_for override changes for persisting institution parameter in the search controller

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,10 +22,10 @@ gem 'jquery-rails', '~> 3.1.0'
 gem 'therubyracer', '~> 0.12.0'
 
 # Use the NYU Libraries assets gem for shared NYU Libraries assets
-gem 'nyulibraries_stylesheets', git: 'https://github.com/NYULibraries/nyulibraries_stylesheets'
-gem 'nyulibraries_templates', git: 'https://github.com/NYULibraries/nyulibraries_templates'
-gem 'nyulibraries_institutions', git: 'https://github.com/NYULibraries/nyulibraries_institutions'
-gem 'nyulibraries_javascripts', git: 'https://github.com/NYULibraries/nyulibraries_javascripts'
+gem 'nyulibraries_stylesheets', git: 'https://github.com/NYULibraries/nyulibraries_stylesheets', tag: 'v1.0.0'
+gem 'nyulibraries_templates', git: 'https://github.com/NYULibraries/nyulibraries_templates', tag: 'v1.0.0'
+gem 'nyulibraries_institutions', git: 'https://github.com/NYULibraries/nyulibraries_institutions', tag: 'v1.0.0'
+gem 'nyulibraries_javascripts', git: 'https://github.com/NYULibraries/nyulibraries_javascripts', tag: 'v1.0.0'
 # Use higher version of Compass CSS framework for sprites, etc.
 gem 'compass-rails', '~> 2.0.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,31 +34,35 @@ GIT
 
 GIT
   remote: https://github.com/NYULibraries/nyulibraries_institutions
-  revision: d265c2d6924ccbded06ea64993e7ab65d93b2f25
+  revision: 809799538d1e08e6b096da567ec4278a412b8779
+  tag: v1.0.0
   specs:
-    nyulibraries_institutions (0.0.0)
+    nyulibraries_institutions (1.0.0)
       institutions (~> 0.1.3)
       rails (>= 4)
 
 GIT
   remote: https://github.com/NYULibraries/nyulibraries_javascripts
-  revision: b7391f5bdd52ef2633015e747750369dd7c585e8
+  revision: f2637c4891f273a6227b4f0fed9245a88539f9b2
+  tag: v1.0.0
   specs:
-    nyulibraries_javascripts (0.0.1)
+    nyulibraries_javascripts (1.0.0)
 
 GIT
   remote: https://github.com/NYULibraries/nyulibraries_stylesheets
-  revision: 4d3586ec74aa0c6895e56febf2078a9025090921
+  revision: 8556ead9e51dc13c4dad883a9c30ea6aed6eaca6
+  tag: v1.0.0
   specs:
-    nyulibraries_stylesheets (0.0.0)
+    nyulibraries_stylesheets (1.0.0)
       bootstrap-sass (~> 3.2)
       compass (>= 1.0.1)
 
 GIT
   remote: https://github.com/NYULibraries/nyulibraries_templates
-  revision: 438549baeb22d38ee65f41681e2131c74fd3d78e
+  revision: 68466155fbaa21cda97e106a502c90bff4c73c4e
+  tag: v1.0.0
   specs:
-    nyulibraries_templates (0.0.1)
+    nyulibraries_templates (1.0.0)
       rails (>= 4)
 
 GEM
@@ -105,6 +109,8 @@ GEM
       gyoku (>= 0.4.0)
       nokogiri
     arel (6.0.3)
+    autoprefixer-rails (6.5.3.1)
+      execjs
     bcrypt (3.1.11)
     better_errors (2.0.0)
       coderay (>= 1.0.0)
@@ -112,8 +118,9 @@ GEM
       rack (>= 0.9.0)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
-    bootstrap-sass (3.2.0.2)
-      sass (~> 3.2)
+    bootstrap-sass (3.3.7)
+      autoprefixer-rails (>= 5.2.1)
+      sass (>= 3.3.4)
     borrow_direct (1.2.0)
       httpclient (~> 2.4)
     builder (3.2.2)

--- a/app/assets/javascripts/resolve/holding_requests.js.coffee
+++ b/app/assets/javascripts/resolve/holding_requests.js.coffee
@@ -1,6 +1,6 @@
 $ ->
   scan_request_option_id = '#entire_no'
-  scan_request_container_class = '#holding-request-option-offsite-scan'
+  scan_request_container_class = '[id^=holding-request-option][id$=-scan]'
   # Select scan request if any of the text inputs have a value
   $(document).on 'keypress', scan_request_container_class + ' fieldset input', ->
     $(this).closest('fieldset').prev('label').find('input').first().prop('checked', true)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,6 +15,34 @@ class ApplicationController < ActionController::Base
     return
   end
 
+  # Override rails url_for to add institution parameter
+  # This has to be defined in the controller so that controller logic
+  # in Umlaut sees the override functionality.
+  #
+  # Ex.
+  # => url_for({controller: 'resolve'}) === 'http://test.host/resolve?umlaut.insitution=#{current_institution}'
+  # => url_for(http://test.host/resolve?rft.object_id=1234) === 'http://test.host/resolve?rft.object_id=1234&umlaut.insitution=#{current_institution}'
+  def url_for(options={})
+    if institution_param.present?
+      if options.is_a?(Hash)
+        options[institution_param_name] ||= institution_param
+      elsif options.is_a?(String)
+        options = append_parameter_to_url(options, institution_param_name, institution_param)
+      end
+    end
+    super(options)
+  end
+
+  def append_parameter_to_url(url, key, value)
+    if url.include?('?')
+      url += '&'
+    else
+      url += '?'
+    end
+    url += "#{key}=#{URI.encode(value.to_s)}"
+  end
+  private :append_parameter_to_url
+
   def current_user_dev
     # Assuming you have a dev user on your local environment
     @current_user ||= User.where(institution_code: :NYU).first

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -52,25 +52,16 @@ module ApplicationHelper
     end
   end
 
-  # override rails url_for to add institution parameter
-  def url_for(options={})
-    if institution_param.present?
-      if options.is_a?(Hash)
-        options[institution_param_name] ||= institution_param
-      elsif options.is_a?(String)
-        options = append_parameter_to_url(options, institution_param_name, institution_param)
-      end
-    end
-    super(options)
-  end
-
-  private
-  def append_parameter_to_url(url, key, value)
-    if url.include?('?')
-      url += '&'
-    else
-      url += '?'
-    end
-    url += "#{key}=#{URI.encode(value.to_s)}"
+  # Override the ActionView url_for to call the application-wide controller
+  # override so that we can specify path-only in views
+  #
+  # Ex.
+  # => url_for({controller: 'resolve'}) === '/resolve?umlaut.institution=#{current_institution}'
+  # => url_for('/resolve?rft.object_id=1234') === '/resolve?rft.object_id=1234&umlaut.institution=#{current_institution}'
+  def url_for(options = {})
+    return controller.url_for(options) unless options.is_a? Hash
+    controller.url_for(
+      options.reverse_merge(only_path: true)
+    )
   end
 end

--- a/config/initializers/skip_passive_login.rb
+++ b/config/initializers/skip_passive_login.rb
@@ -1,4 +1,4 @@
-[UmlautController, ApplicationController].each do |klass|
+[UmlautController, ApplicationController, SearchController, ResolveController].each do |klass|
   klass.class_eval do
     skip_before_filter :passive_login, if: -> { Rails.env.development? || Rails.env.test? }
   end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -79,4 +79,74 @@ describe ApplicationController  do
     end
   end
 
+  describe "#url_for" do
+    context "given options hash" do
+      subject{ controller.url_for(options) }
+
+      context "with query params" do
+        let(:options){ {controller: "resolve", action: "index", key: "value"} }
+
+        context "with institution_param" do
+          let(:institution_param){ :NYUAD }
+          before { allow(controller).to receive(:institution_param).and_return institution_param }
+
+          it { is_expected.to eq "http://test.host/resolve?key=value&umlaut.institution=NYUAD" }
+        end
+
+        context "without either param" do
+          it { is_expected.to eq "http://test.host/resolve?key=value" }
+        end
+      end
+
+      context "without query params" do
+        let(:options){ {controller: "resolve", action: "index"} }
+
+        context "with institution_param" do
+          let(:institution_param){ :NYUAD }
+          before { allow(controller).to receive(:institution_param).and_return institution_param }
+
+          it { is_expected.to eq "http://test.host/resolve?umlaut.institution=NYUAD" }
+        end
+
+        context "without either param" do
+          it { is_expected.to eq "http://test.host/resolve" }
+        end
+      end
+    end
+
+    context "given url string" do
+      subject{ controller.url_for(url) }
+
+      context "with query params" do
+        let(:url){ "https://example.com/some/path?key=value" }
+
+        context "with institution_param" do
+          let(:institution_param){ :NYUAD }
+          before { allow(controller).to receive(:institution_param).and_return institution_param }
+
+          it { is_expected.to eq "https://example.com/some/path?key=value&umlaut.institution=NYUAD" }
+        end
+
+        context "without either param" do
+          it { is_expected.to eq url }
+        end
+      end
+
+      context "without query params" do
+        let(:url){ "https://example.com/some/path" }
+
+        context "with institution_param" do
+          let(:institution_param){ :NYUAD }
+          before { allow(controller).to receive(:institution_param).and_return institution_param }
+
+          it { is_expected.to eq "https://example.com/some/path?umlaut.institution=NYUAD" }
+        end
+
+        context "without either param" do
+          it { is_expected.to eq url }
+        end
+      end
+    end
+  end
+
 end

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -1,3 +1,16 @@
 require 'rails_helper'
 describe SearchController, vcr: {cassette_name: 'search'}  do
+
+  let(:jtitle) { "The New Yorker" }
+  let(:title_search_type) { "exact" }
+  let(:object_id) { '1000000000237705' }
+  let(:institution) { 'NS' }
+
+  describe 'GET /search/journal_search' do
+    before { get :journal_search, "rft.jtitle" => jtitle, "umlaut.title_search_type" => title_search_type, "rft.object_id" => object_id, "umlaut.institution" => institution }
+    subject { response.location }
+    it { should include 'umlaut.institution=NS' }
+    it { should include 'rft.object_id=1000000000237705' }
+    it { should include 'rft.jtitle=The+New+Yorker' }
+  end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -85,72 +85,19 @@ describe ApplicationHelper, vcr: {cassette_name: 'holdings'} do
     end
   end
 
-  describe "url_for" do
-    context "given options hash" do
+  describe '#url_for' do
+    context 'given options hash' do
       subject{ helper.url_for(options) }
 
-      context "with query params" do
+      context 'with query params' do
         let(:options){ {controller: "resolve", action: "index", key: "value"} }
 
-        context "with institution_param" do
-          let(:institution_param){ :NYUAD }
-          before { allow(helper).to receive(:institution_param).and_return institution_param }
-
-          it { is_expected.to eq "/resolve?key=value&umlaut.institution=NYUAD" }
-        end
-
-        context "without either param" do
-          it { is_expected.to eq "/resolve?key=value" }
-        end
+        it { is_expected.to eq "/resolve?key=value" }
       end
 
-      context "without query params" do
-        let(:options){ {controller: "resolve", action: "index"} }
-
-        context "with institution_param" do
-          let(:institution_param){ :NYUAD }
-          before { allow(helper).to receive(:institution_param).and_return institution_param }
-
-          it { is_expected.to eq "/resolve?umlaut.institution=NYUAD" }
-        end
-
-        context "without either param" do
-          it { is_expected.to eq "/resolve" }
-        end
-      end
-    end
-
-    context "given url string" do
-      subject{ helper.url_for(url) }
-
-      context "with query params" do
-        let(:url){ "https://example.com/some/path?key=value" }
-
-        context "with institution_param" do
-          let(:institution_param){ :NYUAD }
-          before { allow(helper).to receive(:institution_param).and_return institution_param }
-
-          it { is_expected.to eq "https://example.com/some/path?key=value&umlaut.institution=NYUAD" }
-        end
-
-        context "without either param" do
-          it { is_expected.to eq url }
-        end
-      end
-
-      context "without query params" do
-        let(:url){ "https://example.com/some/path" }
-
-        context "with institution_param" do
-          let(:institution_param){ :NYUAD }
-          before { allow(helper).to receive(:institution_param).and_return institution_param }
-
-          it { is_expected.to eq "https://example.com/some/path?umlaut.institution=NYUAD" }
-        end
-
-        context "without either param" do
-          it { is_expected.to eq url }
-        end
+      context 'with string as param' do
+        let(:options) { "http://example.com/resolve?key=value" }
+        it { is_expected.to eq "http://example.com/resolve?key=value" }
       end
     end
   end

--- a/spec/helpers/layouts_helper_spec.rb
+++ b/spec/helpers/layouts_helper_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+describe LayoutsHelper do
+
+  describe '#application_javascript' do
+    subject { helper.application_javascript }
+    it { should eql '<script src="/assets/search.js"></script>' }
+  end
+
+  describe '#gauges?' do
+    subject { helper.gauges? }
+    it { should be false }
+  end
+
+  describe '#gauges_tracking_code' do
+    subject { helper.gauges_tracking_code }
+    it 'should not raise an error' do
+      expect { subject }.not_to raise_error
+    end
+  end
+
+  describe '#google_analytics?' do
+    subject { helper.google_analytics? }
+    it { should be false }
+  end
+
+  describe '#google_analytics_tracking_code' do
+    subject { helper.google_analytics_tracking_code }
+    it 'should not raise an error' do
+      expect { subject }.not_to raise_error
+    end
+  end
+
+  describe '#breadcrumbs' do
+    subject { helper.breadcrumbs }
+    it { should include '<a href="http://library.nyu.edu">NYU Libraries</a>' }
+    it { should include '<a href="http://bobcat.library.nyu.edu/nyu">BobCat</a>' }
+    it { should include 'Journals' }
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -56,6 +56,7 @@ RSpec.configure do |config|
   # Include the Devise test helpers
   config.include Devise::TestHelpers, type: :controller
   config.include Devise::TestHelpers, type: :view
+  config.include Devise::TestHelpers, type: :helper
 
   # If true, the base class of anonymous controllers will be inferred
   # automatically. This will be the default behavior in future versions of

--- a/spec/vcr_cassettes/search.yml
+++ b/spec/vcr_cassettes/search.yml
@@ -1,0 +1,33 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://solr.library.edu/select?wt=ruby
+    body:
+      encoding: US-ASCII
+      string: fq=type%3ASfx4%5C%3A%5C%3ALocal%5C%3A%5C%3AAzTitle&sort=score+desc%2C+title_sort_s+asc&q=NEW+YORKER&fl=*+score&qf=title_text&defType=edismax&pf=title_text%5E2.0&bq=title_exact_sm%3ANEW%5C+YORKER%5E10.0&ps=0&start=0&rows=20
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=UTF-8
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 05 Dec 2016 17:37:46 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>80,'params'=>{'q'=>'NEW YORKER','defType'=>'edismax','ps'=>'0','qf'=>'title_text','fl'=>'* score','pf'=>'title_text^2.0','start'=>'0','fq'=>'type:Sfx4\\:\\:Local\\:\\:AzTitle','sort'=>'score desc, title_sort_s asc','rows'=>'20','wt'=>'ruby','bq'=>'title_exact_sm:NEW\\ YORKER^10.0'}},'response'=>{'numFound'=>7,'start'=>0,'maxScore'=>14.476135,'docs'=>[{'id'=>'Sfx4::Local::AzTitle 42063','object_id_ss'=>'1000000000237705','title_display_ss'=>'The New - Yorker (1836-1841)','issn_ss'=>'','isbn_ss'=>'','lccn_ss'=>'','_version_'=>1552768224685195264,'timestamp'=>'2016-12-04T07:06:15.147Z','score'=>14.476135},{'id'=>'Sfx4::Local::AzTitle 109973','object_id_ss'=>'110975413975944','title_display_ss'=>'The New Yorker','issn_ss'=>'0028-792X','isbn_ss'=>'','lccn_ss'=>'2011201780','_version_'=>1552772279452041216,'timestamp'=>'2016-12-04T08:10:42.069Z','score'=>14.261985},{'id'=>'Sfx4::Local::AzTitle 97996','object_id_ss'=>'1000000000759739','title_display_ss'=>'New Yorker Volkszeitung','issn_ss'=>'','isbn_ss'=>'','lccn_ss'=>'','_version_'=>1552771578102546445,'timestamp'=>'2016-12-04T07:59:33.239Z','score'=>2.925251},{'id'=>'Sfx4::Local::AzTitle 95889','object_id_ss'=>'3170000000048826','title_display_ss'=>'Moore\'s Rural New Yorker','issn_ss'=>'','isbn_ss'=>'','lccn_ss'=>'','_version_'=>1552771432202633217,'timestamp'=>'2016-12-04T07:57:14.059Z','score'=>2.4377093},{'id'=>'Sfx4::Local::AzTitle 149399','object_id_ss'=>'3170000000048938','title_display_ss'=>'New Yorker Musik Zeitung','issn_ss'=>'','isbn_ss'=>'','lccn_ss'=>'','_version_'=>1552774676143407109,'timestamp'=>'2016-12-04T08:48:47.717Z','score'=>2.4377093},{'id'=>'Sfx4::Local::AzTitle 159014','object_id_ss'=>'2550000000093256','title_display_ss'=>'Northern New Yorker and Saratoga Farmer','issn_ss'=>'','isbn_ss'=>'','lccn_ss'=>'','_version_'=>1552775270637764608,'timestamp'=>'2016-12-04T08:58:14.68Z','score'=>2.4377093},{'id'=>'Sfx4::Local::AzTitle 90907','object_id_ss'=>'991042741060048','title_display_ss'=>'American agriculturist and the rural New Yorker','issn_ss'=>'0002-7219','isbn_ss'=>'','lccn_ss'=>'sc80001400','_version_'=>1552771154082529283,'timestamp'=>'2016-12-04T07:52:48.837Z','score'=>2.3884575}]}}
+    http_version: 
+  recorded_at: Mon, 05 Dec 2016 17:37:47 GMT
+recorded_with: VCR 2.9.3


### PR DESCRIPTION
@ericgriffis Per [this rather old, but still working, suggestion](http://arjanvandergaag.nl/blog/generating-fancy-routes-with-rails.html) for overriding `url_for` and keeping functionality consistent in controllers and views I made several changes to your original implementation.

This was reported to us as a bug this morning, I'm just noticing though that we were CC'd on an old non-working alias, so you probably didn't see it.

The need for this is that [this umlaut call](https://github.com/team-umlaut/umlaut/blob/master/app/controllers/umlaut/controller_logic.rb#L37), when made in the controller context of an engine gem, is using the core rails, but all the views were successfully using your `url_for` override from the helper method.
