### PR TITLE
Create _header.html.erb

### DIFF
--- a/app/views/hsl/_header.html.erb
+++ b/app/views/hsl/_header.html.erb
@@ -1,0 +1,10 @@
+<header id="header" class="header">
+  <div class="parent"><a href="https://hsl.med.nyu.edu/"><span>NYU Health Sciences Library</span></a></div>
+  <div class="institution"></div>
+</header>
+<nav id="nav1">
+  <%= render_umlaut_permalink %>
+  <ul>
+    <li class="nyu-login"><%= login("umlaut.institution" => institution.code ) %></li>
+  </ul>
+</nav>


### PR DESCRIPTION
GetIT does not display the logo/identity symbol for HSL. (It never has)
I believe adding this header to the HSL folder will resolve that issue for HSL.
